### PR TITLE
#143412465 Re-design the various gaming screens

### DIFF
--- a/public/css/common.css
+++ b/public/css/common.css
@@ -3,12 +3,12 @@
   display: inline-block;
   box-sizing: border-box;
   width: 17.5%;
-  height: 215px;
+  height: 200px;
   padding: 1%;
   margin: 1%;
-  background-color: #ffffff;
+  background-color: #000000;
   border-radius: 8px;
-  color: #252525;
+  color: #ffffff;
   font-family: Arial;
   font-size: 20px;
   font-weight: bold;
@@ -38,7 +38,8 @@
     padding-left: 2%;
     padding-right: 2%; }
   .card.smallest {
-    font-size: 0.750em; }
+    font-size: 0.750em;
+    color: #ffffff; }
     @media (max-width: 520px) {
       .card.smallest {
         font-size: 10px; } }
@@ -59,6 +60,7 @@
       position: absolute;
       right: -0.357em;
       display: inline-block;
+      background-color: #000000;
       content: '.'; }
 
 html, body, .main-container, .cont, #first-section, #inner-container {
@@ -109,7 +111,7 @@ body {
       -webkit-border-radius: 8px;
       -moz-border-radius: 8px;
       border-radius: 8px;
-      background: #252525;
+      background: #00FFFF;
       margin-bottom: 10px;
       margin-top: 5px;
       padding: 5px; }
@@ -159,10 +161,10 @@ body {
       #main-container #app-container #menu-container #abandon-game-button:hover {
         background: #F34444; }
       #main-container #app-container #menu-container #tweet-container {
-        float: center;
+        float: right;
         padding-top: 10px;
-        width: 77px;
-        margin-right: 10px; }
+        width: 87px;
+        margin-right: 5px; }
         @media (max-width: 520px) {
           #main-container #app-container #menu-container #tweet-container {
             float: right;
@@ -180,7 +182,7 @@ body {
           visibility: hidden !important; }
     #main-container #app-container #social-bar-container {
       width: 20%;
-      height: 63%;
+      height: 20%;
       position: absolute;
       right: 0;
       top: 60px; }
@@ -193,13 +195,13 @@ body {
           top: 0;
           left: 0; } }
       #main-container #app-container #social-bar-container #player-container {
-        height: 13.166667%;
+        height: 11.166667%;
         position: relative;
-        padding-top: 4%;
-        padding-bottom: 4%;
+        padding-top: 2%;
+        padding-bottom: 2%;
         min-height: 85px;
         background: #7CE4E8;
-        margin: 0 0 6% 8%;
+        margin: 0 0 2% 4%;
         -webkit-border-radius: 8px;
         -moz-border-radius: 8px;
         border-radius: 8px; }
@@ -218,28 +220,22 @@ body {
           @media (max-width: 520px) {
             #main-container #app-container #social-bar-container #player-container #above-czar-container {
               height: 100%; } }
-          #main-container #app-container #social-bar-container #player-container #above-czar-container #avatar_ {
-            height: 100%;
-            width: 38%;
-            float: left;
-            position: relative;
-            z-index: 999; }
-            #main-container #app-container #social-bar-container #player-container #above-czar-container #avatar_ #king {
-              position: absolute;
-              max-width: 80%;
-              bottom: 20px;
-              -webkit-transform: rotate(-18deg);
-              left: -5px; }
-              @media only screen and (min-width: 521px) and (max-width: 768px) {
-                #main-container #app-container #social-bar-container #player-container #above-czar-container #avatar_ #king {
-                  max-width: 80%;
-                  bottom: 27px; } }
-              @media (max-width: 520px) {
-                #main-container #app-container #social-bar-container #player-container #above-czar-container #avatar_ #king {
-                  max-width: 80%;
-                  bottom: 31px;
-                  left: -3px; } }
-            #main-container #app-container #social-bar-container #player-container #above-czar-container #avatar_ img {
+          #main-container #app-container #social-bar-container #player-container #above-czar-container #king {
+            position: absolute;
+            max-width: 80%;
+            bottom: 20px;
+            -webkit-transform: rotate(-18deg);
+            left: -5px; }
+            @media only screen and (min-width: 521px) and (max-width: 768px) {
+              #main-container #app-container #social-bar-container #player-container #above-czar-container #king {
+                max-width: 80%;
+                bottom: 27px; } }
+            @media (max-width: 520px) {
+              #main-container #app-container #social-bar-container #player-container #above-czar-container #king {
+                max-width: 80%;
+                bottom: 31px;
+                left: -3px; } }
+            #main-container #app-container #social-bar-container #player-container #above-czar-container #king img {
               width: 100%;
               height: 140%;
               float: left;
@@ -249,12 +245,12 @@ body {
               min-width: 40px;
               min-height: 40px; }
               @media only screen and (min-width: 521px) and (max-width: 768px) {
-                #main-container #app-container #social-bar-container #player-container #above-czar-container #avatar_ img {
+                #main-container #app-container #social-bar-container #player-container #above-czar-container #king img {
                   width: 100%;
                   height: 100%;
                   margin-left: 3px; } }
               @media (max-width: 520px) {
-                #main-container #app-container #social-bar-container #player-container #above-czar-container #avatar_ img {
+                #main-container #app-container #social-bar-container #player-container #above-czar-container #king img {
                   height: 69%;
                   width: 100%;
                   min-height: 0;
@@ -291,7 +287,7 @@ body {
             #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-score {
               float: left; }
               #main-container #app-container #social-bar-container #player-container #above-czar-container #player-container-inner #player-score h2 {
-                font-size: 26px;
+                font-size: 18px;
                 margin-top: 0;
                 margin-bottom: 0; }
                 @media only screen and (min-width: 521px) and (max-width: 768px) {
@@ -401,7 +397,7 @@ body {
               left: 0;
               right: 0; }
           #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container {
-            height: 100%; }
+            height: 70%; }
             #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container {
               text-align: center;
               text-align: center;
@@ -418,14 +414,14 @@ body {
               text-indent: 0;
               text-shadow: 1px 1px 0px #ffffff;
               cursor: pointer;
-              background: #FFFFFF;
+              background: #808080;
               text-shadow: none;
               cursor: default;
               border: none;
-              min-width: 85px;
+              min-width: 65px;
               min-height: 85px;
               height: 100%;
-              color: #000; }
+              color: #ffffff; }
               #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container #timer-status-round, #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container #timer-status-czar-choosing {
                 position: absolute;
                 left: 0;
@@ -441,9 +437,9 @@ body {
                     font-size: 12px; } }
               #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container #time {
                 font-family: 'Lobster', cursive;
-                font-size: 110px;
+                font-size: 90px;
                 position: absolute;
-                bottom: 25%;
+                bottom: 15%;
                 left: 0;
                 right: 0; }
                 @media only screen and (max-width: 1024px) {
@@ -453,7 +449,7 @@ body {
                   #main-container #app-container #gameplay-container #upper-gameplay-container #menu-timeremaining-container #timer-container #inner-timer-container #time {
                     font-size: 73px; } }
         #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer {
-          height: 100%;
+          height: 80%;
           float: left;
           width: 79%; }
           @media only screen and (min-width: 521px) and (max-width: 768px) {
@@ -466,11 +462,11 @@ body {
               width: 71%;
               margin-left: 1%; } }
           #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner {
-            width: 100%;
-            height: 100%; }
+            width: 80%;
+            height: 80%; }
             #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card {
               width: 100%;
-              margin: 0px auto;
+              margin: 15px auto;
               display: block; }
               #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #notifications {
                 position: absolute;
@@ -496,7 +492,7 @@ body {
                   float: left;
                   text-align: center; }
                 #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #player-count-container #player-count {
-                  font-size: 33px; }
+                  font-size: 25px; }
                   @media (max-width: 520px) {
                     #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #startGame #player-count-container #player-count {
                       font-size: 21px; } }
@@ -545,15 +541,15 @@ body {
                     #main-container #app-container #gameplay-container #upper-gameplay-container #question-container-outer #question-container-inner .card #game-end-info .game-end-headline {
                       font-size: 18px; } }
       #main-container #app-container #gameplay-container #info-container {
-        width: 100%;
+        width: 90%;
         background: #252525;
-        color: white;
+        color: #ffffff;
         -webkit-border-radius: 8px;
         -moz-border-radius: 8px;
         border-radius: 8px;
         text-align: center;
         padding: 15px;
-        height: 50%;
+        height: auto;
         margin-top: 10px; }
         @media only screen and (min-width: 521px) and (max-width: 768px) {
           #main-container #app-container #gameplay-container #info-container {
@@ -569,21 +565,22 @@ body {
           width: 90%;
           margin: 0 5%; }
           #main-container #app-container #gameplay-container #info-container #inner-info #lobby-how-to-play {
-            font-size: 18px;
+            font-size: 40px;
+            text-decoration: underline;
             margin-top: 10px; }
             @media only screen and (min-width: 521px) and (max-width: 768px) {
               #main-container #app-container #gameplay-container #info-container #inner-info #lobby-how-to-play {
                 font-size: 14px; } }
-          #main-container #app-container #gameplay-container #info-container #inner-info ol {
+          #main-container #app-container #gameplay-container #info-container #inner-info ul {
             margin-top: 10px;
             font-family: "helvetica neue", helvetica, sans-serif;
             text-align: left;
-            font-size: 17px; }
-            #main-container #app-container #gameplay-container #info-container #inner-info ol li {
-              list-style-type: decimal;
+            font-size: 25px; }
+            #main-container #app-container #gameplay-container #info-container #inner-info ul li {
+              list-style-type: disc;
               margin-bottom: 5px; }
             @media (max-width: 520px) {
-              #main-container #app-container #gameplay-container #info-container #inner-info ol {
+              #main-container #app-container #gameplay-container #info-container #inner-info ul {
                 font-size: 13px;
                 padding: 0px 10px 10px 10px; } }
       #main-container #app-container #gameplay-container #game-end-container {
@@ -790,7 +787,7 @@ body {
                 width: 53%; } }
       #main-container #app-container #gameplay-container #cards-container {
         width: 100%;
-        background: #252525;
+        background: transparent;
         margin-top: 11px;
         -webkit-border-radius: 8px;
         -moz-border-radius: 8px;

--- a/public/css/common.scss
+++ b/public/css/common.scss
@@ -287,15 +287,15 @@ background-size: cover;
     display: inline-block;
     box-sizing: border-box;
     width: 17.5%;
-    height: 215px;
+    height: 200px;
     padding: 1%;
     margin: 1%;
 
-    background-color: #ffffff;
+    background-color: #000000;
 
     border-radius: 8px;
 
-    color: #252525;
+    color: #ffffff;
     font-family: Arial;
     font-size: 20px;
     font-weight: bold;
@@ -337,6 +337,7 @@ background-size: cover;
 
     &.smallest {
         font-size: 0.750em;
+        color:#ffffff;
 
         @include mobile-only{
             font-size: 10px; //play with later
@@ -352,7 +353,7 @@ background-size: cover;
         text-decoration: none;
 
         height: 1em;
-        border-bottom: 0.125em solid white;
+        border-bottom: 0.125em solid white    ;
         margin-bottom: -0.125em;
 
         .small {
@@ -367,6 +368,7 @@ background-size: cover;
             position: absolute;
             right: -0.357em;
             display: inline-block;
+            background-color: #000000;
             content: '.';
         }
     }
@@ -432,7 +434,7 @@ body{
             -webkit-border-radius: 8px;
             -moz-border-radius: 8px;
             border-radius: 8px;
-            background: #252525;
+            background: #00FFFF;
             margin-bottom: 10px;
             margin-top: 5px;
             padding: 5px;
@@ -467,7 +469,7 @@ body{
 
             #abandon-game-button{
                 display: inline-block;
-                float:right;
+                float: right;
                 border-radius: 8px;
                 -moz-border-radius: 8px;
                 -webkit-border-radius: 8px;
@@ -498,10 +500,10 @@ body{
             }
 
             #tweet-container{
-                float: center;
+                float: right;
                 padding-top: 10px;
-                width: 77px;
-                margin-right: 10px;
+                width: 87px;
+                margin-right: 5px;
 
                 @include mobile-only{
                     float: right;
@@ -529,7 +531,7 @@ body{
 
         #social-bar-container{
             width: 20%;
-            height: 63%;
+            height: 20%;
             position: absolute;
             right: 0;
             top: 60px;
@@ -541,17 +543,16 @@ body{
                 position: relative;
                 top: 0;
                 left: 0;
-                // background: white;
             }
 
             #player-container{
-                height: 13.166667%;
+                height: 11.166667%;
                 position: relative;
-                padding-top: 4%;
-                padding-bottom: 4%;
+                padding-top: 2%;
+                padding-bottom: 2%;
                 min-height: 85px;
                 background: #7CE4E8;
-                margin: 0 0 6% 8%;
+                margin: 0 0 2% 4%;
                 @include br;
 
                 @include mobile-only{
@@ -572,12 +573,6 @@ body{
                         height: 100%;
                     }
 
-                    #avatar_ {
-                        height: 100%;
-                        width: 38%;
-                        float: left;
-                        position: relative;
-                        z-index: 999;
 
                         #king {
                            position: absolute;
@@ -596,7 +591,6 @@ body{
                                 bottom: 31px;
                                 left: -3px;
                            }
-                         }
 
 
                         img {
@@ -667,7 +661,7 @@ body{
 
                             h2{
 
-                                font-size: 26px;
+                                font-size: 18px;
                                 margin-top: 0;
                                 margin-bottom: 0;
 
@@ -792,19 +786,19 @@ body{
                     }
 
                     #timer-container {
-                        height: 100%;
+                        height: 70%;
 
                         #inner-timer-container{
                             text-align: center;
                             @include soft-button;
-                            background: #ffffff;
+                            background:#808080;
                             text-shadow: none;
                             cursor: default;
                             border: none;
-                            min-width: 85px;
+                            min-width: 65px;
                             min-height: 85px;
                             height: 100%;
-                            color: #000;
+                            color: #ffffff;
 
                             #timer-status-round, #timer-status-czar-choosing{
                                 position: absolute;
@@ -825,9 +819,9 @@ body{
 
                             #time{
                                 font-family: 'Lobster', cursive;
-                                font-size: 110px;
+                                font-size: 90px;
                                 position: absolute;
-                                bottom: 25%;
+                                bottom: 15%;
                                 left: 0;
                                 right: 0;
 
@@ -844,7 +838,7 @@ body{
                  }
 
                 #question-container-outer {
-                    height: 100%;
+                    height: 80%;
                     float: left;
                     width: 79%;
 
@@ -860,11 +854,11 @@ body{
                     }
 
                     #question-container-inner{
-                        width: 100%;
-                        height: 100%;
+                        width: 80%;
+                        height: 80%;
                         .card{
                             width: 100%;
-                            margin: 0px auto;
+                            margin: 15px auto;
                             display: block;
 
                             #notifications {
@@ -900,7 +894,7 @@ body{
 
                                 #player-count-container{
                                     #player-count{
-                                        font-size: 33px;
+                                        font-size: 25px;
 
                                         @include mobile-only{
                                             font-size: 21px;
@@ -976,13 +970,13 @@ body{
                 }
             }
             #info-container{
-                width: 100%;
+                width: 90%;
                 background: #252525;
-                color: white;
+                color: #ffffff;
                 @include br;
                 text-align: center;
                 padding: 15px;
-                height: 50%;
+                height: auto;
                 margin-top: 10px;
 
                 @include tablet-portrait-only{
@@ -1002,7 +996,8 @@ body{
                     margin: 0 5%;
 
                     #lobby-how-to-play{
-                        font-size: 18px;
+                        font-size: 40px;
+                        text-decoration: underline;
                         margin-top: 10px;
 
                         @include tablet-portrait-only{
@@ -1010,14 +1005,14 @@ body{
                         }
                     }
 
-                    ol{
+                    ul{
                         margin-top: 10px;
                         font-family: $main-font;
                         text-align: left;
-                        font-size: 17px;
+                        font-size: 25px;
 
                         li{
-                            list-style-type: decimal;
+                            list-style-type: disc;
                             margin-bottom: 5px;
                         }
 
@@ -1214,7 +1209,7 @@ body{
 
             #cards-container{
                 width: 100%;
-                background: #252525;
+                background: transparent;
                 margin-top: 11px;
                 @include br;
 

--- a/public/css/common.scss
+++ b/public/css/common.scss
@@ -9,7 +9,7 @@ $mq-custom-wide : 1200px !default;
 
 $color-background: #ffffff;
 
-  @mixin html {
+@mixin html {
 background-image: url("../img/background_edited.jpg");
 background-position: center;
 background-blend-mode: color#ffffff;
@@ -21,1292 +21,1293 @@ background-size: cover;
 
 // Both portrait and landscape
 @mixin mobile-only {
-    @media (max-width : $mq-mobile-landscape) {
-        @content;
-    }
+  @media (max-width : $mq-mobile-landscape) {
+      @content;
+  }
 }
 
 // Everything up to and including the portrait width of the phone
 // Since it's the smallest query it doesn't need a min
 @mixin mobile-portrait-only {
-    @media (max-width : $mq-mobile-portrait) {
-        @content;
-    }
+  @media (max-width : $mq-mobile-portrait) {
+      @content;
+  }
 }
 
 // Everything up to and including the mobile portrait
 @mixin mobile-portrait-and-below {
-    @media (max-width : $mq-mobile-portrait) {
-        @content;
-    }
+  @media (max-width : $mq-mobile-portrait) {
+      @content;
+  }
 }
 
 // Everything above and including the mobile portrait
 @mixin mobile-portrait-and-up {
-    @media (min-width : $mq-mobile-portrait) {
-        @content;
-    }
+  @media (min-width : $mq-mobile-portrait) {
+      @content;
+  }
 }
 
 // Everthing larger than a portrait mobile up until mobile landscape
 @mixin mobile-landscape-only {
-    @media only screen and (min-width : $mq-mobile-portrait + 1) and (max-width : $mq-mobile-landscape) {
-        @content;
-    }
+  @media only screen and (min-width : $mq-mobile-portrait + 1) and (max-width : $mq-mobile-landscape) {
+      @content;
+  }
 }
 
 // Everything up to and including the mobile landscape width
 @mixin mobile-landscape-and-below {
-    @media only screen and (max-width : $mq-mobile-landscape) {
-        @content;
-    }
+  @media only screen and (max-width : $mq-mobile-landscape) {
+      @content;
+  }
 }
 
 // Everything above and including the mobile landscape width
 @mixin mobile-landscape-and-up {
-    @media only screen and (min-width : $mq-mobile-portrait + 1) {
-        @content;
-    }
+  @media only screen and (min-width : $mq-mobile-portrait + 1) {
+      @content;
+  }
 }
 
 // Both the portrait and landscape width of the tablet
 // Larger than a landscape mobile but less than or equal to a landscape tablet
 @mixin tablet-only {
-    @media only screen and (min-width : $mq-mobile-landscape + 1) and (max-width : $mq-tablet-landscape) {
-        @content;
-    }
+  @media only screen and (min-width : $mq-mobile-landscape + 1) and (max-width : $mq-tablet-landscape) {
+      @content;
+  }
 }
 
 // Everything larger than mobile landscape up until the portrait width of the tablet
 @mixin tablet-portrait-only {
-    @media only screen and (min-width : $mq-mobile-landscape + 1) and (max-width : $mq-tablet-portrait) {
-        @content;
-    }
+  @media only screen and (min-width : $mq-mobile-landscape + 1) and (max-width : $mq-tablet-portrait) {
+      @content;
+  }
 }
 
 // Everything below and including the portrait width of the tablet
 @mixin tablet-portrait-and-below {
-    @media only screen and (max-width : $mq-tablet-portrait) {
-        @content;
-    }
+  @media only screen and (max-width : $mq-tablet-portrait) {
+      @content;
+  }
 }
 
 // Larger than portrait but less than or equal to the landscape width
 @mixin tablet-landscape-only {
-    @media only screen and (min-width : $mq-tablet-portrait + 1) and (max-width : $mq-tablet-landscape) {
-        @content;
-    }
+  @media only screen and (min-width : $mq-tablet-portrait + 1) and (max-width : $mq-tablet-landscape) {
+      @content;
+  }
 }
 
 // Up to and including the tablet landscape
 @mixin tablet-landscape-and-below {
-    @media only screen and (max-width : $mq-tablet-landscape) {
-        @content;
-    }
+  @media only screen and (max-width : $mq-tablet-landscape) {
+      @content;
+  }
 }
 
 // Everything larger than a landscape tablet
 @mixin desktop-and-below {
-    @media only screen and (max-width : $mq-tablet-landscape + 1) {
-        @content;
-    }
+  @media only screen and (max-width : $mq-tablet-landscape + 1) {
+      @content;
+  }
 }
 
 @mixin custom-wide {
-    @media only screen and (min-width : $mq-custom-wide + 1) {
-        @content;
-    }
+  @media only screen and (min-width : $mq-custom-wide + 1) {
+      @content;
+  }
 }
 
 @mixin br{
-    -webkit-border-radius: 8px;
-    -moz-border-radius: 8px;
-    border-radius: 8px;
+  -webkit-border-radius: 8px;
+  -moz-border-radius: 8px;
+  border-radius: 8px;
 }
 
 @mixin br-bottom {
-    -webkit-border-bottom-right-radius: 8px;
-    -webkit-border-bottom-left-radius: 8px;
-    -moz-border-radius-bottomright: 8px;
-    -moz-border-radius-bottomleft: 8px;
-    border-bottom-right-radius: 8px;
-    border-bottom-left-radius: 8px;
+  -webkit-border-bottom-right-radius: 8px;
+  -webkit-border-bottom-left-radius: 8px;
+  -moz-border-radius-bottomright: 8px;
+  -moz-border-radius-bottomleft: 8px;
+  border-bottom-right-radius: 8px;
+  border-bottom-left-radius: 8px;
 }
 
 @mixin button {
-    -moz-box-shadow: inset 0px 1px 0px 0px #ffffff;
-    -webkit-box-shadow: inset 0px 1px 0px 0px #ffffff;
-    box-shadow: inset 0px 1px 0px 0px #ffffff;
-    background: -webkit-gradient( linear, left top, left bottom, color-stop(0.05, #fcfcfc), color-stop(1, #f0f0f0) );
-    background: -moz-linear-gradient( center top, #fcfcfc 5%, #f0f0f0 100% );
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fcfcfc', endColorstr='#f0f0f0');
-    background-color: #fcfcfc;
-    -webkit-border-top-left-radius: 8px;
-    -moz-border-radius-topleft: 8px;
-    border-top-left-radius: 8px;
-    -webkit-border-top-right-radius: 8px;
-    -moz-border-radius-topright: 8px;
-    border-top-right-radius: 8px;
-    -webkit-border-bottom-right-radius: 8px;
-    -moz-border-radius-bottomright: 8px;
-    border-bottom-right-radius: 8px;
-    -webkit-border-bottom-left-radius: 8px;
-    -moz-border-radius-bottomleft: 8px;
-    border-bottom-left-radius: 8px;
-    text-indent: 0;
-    border: 1px solid #dcdcdc;
-    display: inline-block;
-    color: #777777;
-    font-family: arial;
-    font-size: 50px;
-    font-weight: bold;
-    font-style: normal;
-    height: 200px;
-    line-height: 200px;
-    width: 300px;
-    text-decoration: none;
-    text-align: center;
-    text-shadow: 1px 1px 0px #ffffff;
-    margin-top: 15px;
-    cursor: pointer;
+  -moz-box-shadow: inset 0px 1px 0px 0px #ffffff;
+  -webkit-box-shadow: inset 0px 1px 0px 0px #ffffff;
+  box-shadow: inset 0px 1px 0px 0px #ffffff;
+  background: -webkit-gradient( linear, left top, left bottom, color-stop(0.05, #fcfcfc), color-stop(1, #f0f0f0) );
+  background: -moz-linear-gradient( center top, #fcfcfc 5%, #f0f0f0 100% );
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fcfcfc', endColorstr='#f0f0f0');
+  background-color: #fcfcfc;
+  -webkit-border-top-left-radius: 8px;
+  -moz-border-radius-topleft: 8px;
+  border-top-left-radius: 8px;
+  -webkit-border-top-right-radius: 8px;
+  -moz-border-radius-topright: 8px;
+  border-top-right-radius: 8px;
+  -webkit-border-bottom-right-radius: 8px;
+  -moz-border-radius-bottomright: 8px;
+  border-bottom-right-radius: 8px;
+  -webkit-border-bottom-left-radius: 8px;
+  -moz-border-radius-bottomleft: 8px;
+  border-bottom-left-radius: 8px;
+  text-indent: 0;
+  border: 1px solid #dcdcdc;
+  display: inline-block;
+  color: #777777;
+  font-family: arial;
+  font-size: 50px;
+  font-weight: bold;
+  font-style: normal;
+  height: 200px;
+  line-height: 200px;
+  width: 300px;
+  text-decoration: none;
+  text-align: center;
+  text-shadow: 1px 1px 0px #ffffff;
+  margin-top: 15px;
+  cursor: pointer;
 }
 
 @mixin button-hover {
-    background: -webkit-gradient( linear, left top, left bottom, color-stop(0.05, #f0f0f0), color-stop(1, #ededed) );
-    background: -moz-linear-gradient( center top, #f0f0f0 5%, #ededed 100% );
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f0f0f0', endColorstr='#ededed');
-    background-color: #f0f0f0;
-    color: #4e4e4e;
+  background: -webkit-gradient( linear, left top, left bottom, color-stop(0.05, #f0f0f0), color-stop(1, #ededed) );
+  background: -moz-linear-gradient( center top, #f0f0f0 5%, #ededed 100% );
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f0f0f0', endColorstr='#ededed');
+  background-color: #f0f0f0;
+  color: #4e4e4e;
 }
 
 
 @mixin button-smaller {
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fcfcfc', endColorstr='#f0f0f0');
-    background-color: white;
-    -webkit-border-top-left-radius: 8px;
-    -moz-border-radius-topleft: 8px;
-    border-top-left-radius: 8px;
-    -webkit-border-top-right-radius: 8px;
-    -moz-border-radius-topright: 8px;
-    border-top-right-radius: 8px;
-    -webkit-border-bottom-right-radius: 8px;
-    -moz-border-radius-bottomright: 8px;
-    border-bottom-right-radius: 8px;
-    -webkit-border-bottom-left-radius: 8px;
-    -moz-border-radius-bottomleft: 8px;
-    border-bottom-left-radius: 8px;
-    text-indent: 0;
-    display: inline-block;
-    color: #252525;
-    font-size: 39px;
-    font-weight: bold;
-    font-style: normal;
-    height: 100px;
-    line-height: 100px;
-    width: 200px;
-    text-decoration: none;
-    text-align: center;
-    cursor: pointer;
-    margin: 5px auto;
-    display: block;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fcfcfc', endColorstr='#f0f0f0');
+  background-color: white;
+  -webkit-border-top-left-radius: 8px;
+  -moz-border-radius-topleft: 8px;
+  border-top-left-radius: 8px;
+  -webkit-border-top-right-radius: 8px;
+  -moz-border-radius-topright: 8px;
+  border-top-right-radius: 8px;
+  -webkit-border-bottom-right-radius: 8px;
+  -moz-border-radius-bottomright: 8px;
+  border-bottom-right-radius: 8px;
+  -webkit-border-bottom-left-radius: 8px;
+  -moz-border-radius-bottomleft: 8px;
+  border-bottom-left-radius: 8px;
+  text-indent: 0;
+  display: inline-block;
+  color: #252525;
+  font-size: 39px;
+  font-weight: bold;
+  font-style: normal;
+  height: 100px;
+  line-height: 100px;
+  width: 200px;
+  text-decoration: none;
+  text-align: center;
+  cursor: pointer;
+  margin: 5px auto;
+  display: block;
 }
 
 @mixin button-hover-smaller {
-    background: -webkit-gradient( linear, left top, left bottom, color-stop(0.05, #f0f0f0), color-stop(1, #ededed) );
-    background: -moz-linear-gradient( center top, #f0f0f0 5%, #ededed 100% );
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f0f0f0', endColorstr='#ededed');
-    background-color: #f0f0f0;
-    color: #4e4e4e;
+  background: -webkit-gradient( linear, left top, left bottom, color-stop(0.05, #f0f0f0), color-stop(1, #ededed) );
+  background: -moz-linear-gradient( center top, #f0f0f0 5%, #ededed 100% );
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f0f0f0', endColorstr='#ededed');
+  background-color: #f0f0f0;
+  color: #4e4e4e;
 }
 
 @mixin button-smallest {
-    -moz-box-shadow: inset 0px 1px 0px 0px #ffffff;
-    -webkit-box-shadow: inset 0px 1px 0px 0px #ffffff;
-    box-shadow: inset 0px 1px 0px 0px #ffffff;
-    background: -webkit-gradient( linear, left top, left bottom, color-stop(0.05, #fcfcfc), color-stop(1, #f0f0f0) );
-    background: -moz-linear-gradient( center top, #fcfcfc 5%, #f0f0f0 100% );
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fcfcfc', endColorstr='#f0f0f0');
-    background-color: #fcfcfc;
-    -webkit-border-top-left-radius: 8px;
-    -moz-border-radius-topleft: 8px;
-    border-top-left-radius: 8px;
-    -webkit-border-top-right-radius: 8px;
-    -moz-border-radius-topright: 8px;
-    border-top-right-radius: 8px;
-    -webkit-border-bottom-right-radius: 8px;
-    -moz-border-radius-bottomright: 8px;
-    border-bottom-right-radius: 8px;
-    -webkit-border-bottom-left-radius: 8px;
-    -moz-border-radius-bottomleft: 8px;
-    border-bottom-left-radius: 8px;
-    text-indent: 0;
-    border: 1px solid #dcdcdc;
-    display: inline-block;
-    color: #777777;
-    font-family: arial;
-    font-size: 19px;
-    font-weight: bold;
-    font-style: normal;
-    height: 50px;
-    line-height: 50px;
-    width: 100px;
-    text-decoration: none;
-    text-align: center;
-    text-shadow: 1px 1px 0px #ffffff;
-    cursor: pointer;
-    margin: 5px auto;
-    display: block;
+  -moz-box-shadow: inset 0px 1px 0px 0px #ffffff;
+  -webkit-box-shadow: inset 0px 1px 0px 0px #ffffff;
+  box-shadow: inset 0px 1px 0px 0px #ffffff;
+  background: -webkit-gradient( linear, left top, left bottom, color-stop(0.05, #fcfcfc), color-stop(1, #f0f0f0) );
+  background: -moz-linear-gradient( center top, #fcfcfc 5%, #f0f0f0 100% );
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fcfcfc', endColorstr='#f0f0f0');
+  background-color: #fcfcfc;
+  -webkit-border-top-left-radius: 8px;
+  -moz-border-radius-topleft: 8px;
+  border-top-left-radius: 8px;
+  -webkit-border-top-right-radius: 8px;
+  -moz-border-radius-topright: 8px;
+  border-top-right-radius: 8px;
+  -webkit-border-bottom-right-radius: 8px;
+  -moz-border-radius-bottomright: 8px;
+  border-bottom-right-radius: 8px;
+  -webkit-border-bottom-left-radius: 8px;
+  -moz-border-radius-bottomleft: 8px;
+  border-bottom-left-radius: 8px;
+  text-indent: 0;
+  border: 1px solid #dcdcdc;
+  display: inline-block;
+  color: #777777;
+  font-family: arial;
+  font-size: 19px;
+  font-weight: bold;
+  font-style: normal;
+  height: 50px;
+  line-height: 50px;
+  width: 100px;
+  text-decoration: none;
+  text-align: center;
+  text-shadow: 1px 1px 0px #ffffff;
+  cursor: pointer;
+  margin: 5px auto;
+  display: block;
 }
 
 @mixin button-hover-smallest {
-    background: -webkit-gradient( linear, left top, left bottom, color-stop(0.05, #f0f0f0), color-stop(1, #ededed) );
-    background: -moz-linear-gradient( center top, #f0f0f0 5%, #ededed 100% );
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f0f0f0', endColorstr='#ededed');
-    background-color: #f0f0f0;
-    color: #4e4e4e;
+  background: -webkit-gradient( linear, left top, left bottom, color-stop(0.05, #f0f0f0), color-stop(1, #ededed) );
+  background: -moz-linear-gradient( center top, #f0f0f0 5%, #ededed 100% );
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f0f0f0', endColorstr='#ededed');
+  background-color: #f0f0f0;
+  color: #4e4e4e;
 }
 
 @mixin soft-button{
-    text-align: center;
-    position: relative;
-    font-weight: bold;
-    @include br;
-    -moz-box-shadow: inset 0px 1px 0px 0px #ffffff;
-    -webkit-box-shadow: inset 0px 1px 0px 0px #ffffff;
-    box-shadow: inset 0px 1px 0px 0px #ffffff;
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fcfcfc', endColorstr='#f0f0f0');
-    background-color: #D5D5D5;
-    text-indent: 0;
-    text-shadow: 1px 1px 0px #ffffff;
-    cursor: pointer;
+  text-align: center;
+  position: relative;
+  font-weight: bold;
+  @include br;
+  -moz-box-shadow: inset 0px 1px 0px 0px #ffffff;
+  -webkit-box-shadow: inset 0px 1px 0px 0px #ffffff;
+  box-shadow: inset 0px 1px 0px 0px #ffffff;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fcfcfc', endColorstr='#f0f0f0');
+  background-color: #D5D5D5;
+  text-indent: 0;
+  text-shadow: 1px 1px 0px #ffffff;
+  cursor: pointer;
 }
 
 .card {
-    position: relative;
+  position: relative;
 
-    display: inline-block;
-    box-sizing: border-box;
-    width: 17.5%;
-    height: 200px;
-    padding: 1%;
-    margin: 1%;
+  display: inline-block;
+  box-sizing: border-box;
+  width: 17.5%;
+  height: 200px;
+  padding: 1%;
+  margin: 1%;
+  background-color: #000000;
+  border-radius: 8px;
+  color: #ffffff;
+  font-family: Arial;
+  font-size: 20px;
+  font-weight: bold;
 
-    background-color: #000000;
+  vertical-align: top;
 
-    border-radius: 8px;
+  @include mobile-only{
+      font-size: 14px;
+      height: 115px;
+      word-wrap: break-word;
+  }
 
-    color: #ffffff;
-    font-family: Arial;
-    font-size: 20px;
-    font-weight: bold;
+  &.how-to {
+      font-size: 1.4rem;
+  }
 
-    vertical-align: top;
+  #selection-number {
+      position: absolute;
+      bottom: 1px;
+      left: 7px;
+      font-size: 18px;
+  }
 
-    @include mobile-only{
-        font-size: 14px;
-        height: 115px;
-        word-wrap: break-word;
-    }
+  &.black {
+      background: #252525;
+      border-color: white;
+      color: white;
+  }
 
-    &.how-to {
-        font-size: 1.4rem;
-    }
+  &.longBlack {
+      background: #252525;
+      border-color: white;
+      color: white;
+      height: 100%;
+      width: 35.5em;
+      padding-left: 2%;
+      padding-right: 2%;
+  }
 
-    #selection-number {
-        position: absolute;
-        bottom: 1px;
-        left: 7px;
-        font-size: 18px;
-    }
+  &.smallest {
+      font-size: 0.750em;
+      color: #ffffff;
 
-    &.black {
-        background: #252525;
-        border-color: white;
-        color: white;
-    }
+      @include mobile-only{
+          font-size: 10px;
+      }
+  }
 
-    &.longBlack {
-        background: #252525;
-        border-color: white;
-        color: white;
-        height: 100%;
-        width: 35.5em;
-        padding-left: 2%;
-        padding-right: 2%;
-    }
+  u {
+      position: relative;
+      content: '';
+      display: inline-block;
+      width: 25%;
 
-    &.smallest {
-        font-size: 0.750em;
-        color:#ffffff;
+      text-decoration: none;
 
-        @include mobile-only{
-            font-size: 10px; //play with later
-        }
-    }
+      height: 1em;
+      border-bottom: 0.125em solid #ffffff;
+      margin-bottom: -0.125em;
 
-    u {
-        position: relative;
-        content: '';
-        display: inline-block;
-        width: 25%;
+      .small {
+          width: 25%;
+      }
 
-        text-decoration: none;
+      .big {
+          width: 75%;
+      }
 
-        height: 1em;
-        border-bottom: 0.125em solid white    ;
-        margin-bottom: -0.125em;
-
-        .small {
-            width: 25%;
-        }
-
-        .big {
-            width: 75%;
-        }
-
-        .end:after {
-            position: absolute;
-            right: -0.357em;
-            display: inline-block;
-            background-color: #000000;
-            content: '.';
-        }
-    }
+      .end:after {
+          position: absolute;
+          right: -0.357em;
+          display: inline-block;
+          background-color: #000000;
+          content: '.';
+      }
+  }
 }
 
 html, body, .main-container, .cont, #first-section, #inner-container{
-    height: 100%;
+  height: 100%;
 }
 
 html{
-    // margin: 20px;
-    // margin-top: 5px;
-    // background: url(/img/minimal-wallpaper.jpg) no-repeat center center fixed;
-    // -webkit-background-size: cover;
-    // -moz-background-size: cover;
-    // -o-background-size: cover;
-    // background-size: cover;
-  @include html;
-  background-attachment: fixed;
-  background-repeat: no-repeat;
-  position: relative;
+  // margin: 20px;
+  // margin-top: 5px;
+  // background: url(/img/minimal-wallpaper.jpg) no-repeat center center fixed;
+  // -webkit-background-size: cover;
+  // -moz-background-size: cover;
+  // -o-background-size: cover;
+  // background-size: cover;
+@include html;
+background-attachment: fixed;
+background-repeat: no-repeat;
+position: relative;
 
-    @include mobile-only{
-        //margin: 3px;
-        margin-top: 0px;
-    }
+  @include mobile-only{
+      //margin: 3px;
+      margin-top: 0px;
+  }
 }
 body{
-    font-family: $main-font;
-    background: transparent;
-    margin: 10px;
+  font-family: $main-font;
+  background: transparent;
+  margin: 10px;
 
-    @include tablet-portrait-only{
-        margin: 5px;
-    }
+  @include tablet-portrait-only{
+      margin: 5px;
+  }
 
-    @include mobile-only{
-        margin: 1px;
-    }
+  @include mobile-only{
+      margin: 1px;
+  }
 }
 
 .navbar .nav>li>a.brand {
-    padding-left:20px;
-    margin-left:0
+  padding-left:20px;
+  margin-left:0
 }
 
 .content {
-    margin-top:50px;
-    width:70%
+  margin-top:50px;
+  width:70%
 }
 
 
 #main-container{
-    height: 100%;
-    #app-container {
-        height: 100%;
-        max-width: 1200px;
-        margin: 0px auto;
-        position: relative;
+  height: 100%;
+  #app-container {
+      height: 100%;
+      max-width: 1200px;
+      margin: 0px auto;
+      position: relative;
 
-        #menu-container{
-            width: 100%;
-            -webkit-border-radius: 8px;
-            -moz-border-radius: 8px;
-            border-radius: 8px;
-            background: #00FFFF;
-            margin-bottom: 10px;
-            margin-top: 5px;
-            padding: 5px;
+      #menu-container{
+          background: #00ffff;
+          width: 100%;
+          margin-bottom: 10px;
+          margin-top: 5px;
+          padding: 5px;
+          -webkit-border-radius: 8px;
+          -moz-border-radius: 8px;
+          border-radius: 8px;
+          
 
-            @include mobile-only{
-                margin-bottom: 1px;
-                margin-top: 0px;
-            }
+          @include mobile-only{
+              margin-bottom: 1px;
+              margin-top: 0px;
+          }
 
-            #logo{
-                display: inline-block;
-                margin-left: 10px;
-                font-size: 28px;
-                font-family: 'Lobster', cursive;
+          #logo{
+              display: inline-block;
+              margin-left: 10px;
+              font-size: 28px;
+              font-family: 'Lobster', cursive;
 
-                @include mobile-only{
-                    font-size: 20px;
+              @include mobile-only{
+                  font-size: 20px;
+              }
+
+              #first-word{
+                  color: #000000;
+              }
+
+              #second-word{
+                  color: #000000;
+              }
+
+              #third-word{
+                  color: #000000;
+              }
+          }
+
+          #abandon-game-button{
+              display: inline-block;
+              float: right;
+              border-radius: 8px;
+              -moz-border-radius: 8px;
+              -webkit-border-radius: 8px;
+              font-size: 20px;
+              font-size: 1.25rem;
+              font-weight: 400;
+              text-align: center;
+              color: white;
+              background: #000000;
+              margin-top: 3px;
+              margin-bottom: 3px;
+              margin-right: 10px;
+              padding: 0.65em 20px;
+              width: 140px;
+              cursor: pointer;
+
+              @include mobile-only{
+                  font-size: 0.7rem;
+                  margin-top: 5px;
+                  margin-right: 1px;
+                  padding: 5px;
+                  width: 60px;
+              }
+          }
+
+          #abandon-game-button:hover{
+              background:#F34444;
+          }
+
+          #tweet-container{
+              float: right;
+              padding-top: 10px;
+              width: 87px;
+              margin-right: 5px;
+
+              @include mobile-only{
+                  float: right;
+                  padding-top: 6px;
+                  width: 55px;
+                  overflow: hidden;
+                  margin-right: 11px;
+              }
+
+              .hcount .count-o{
+                  display: none !important;
+                  width: 0 !important;
+              }
+
+              .count-0{
+                  width: 0 !important;
+              }
+
+              .count-ready .count-o {
+                  visibility: visible;
+                  visibility: hidden !important;
+              }
+          }
+      }
+
+      #social-bar-container{
+          width: 20%;
+          height: 20%;
+          position: absolute;
+          right: 0;
+          top: 60px;
+
+          @include mobile-only{
+              top: auto;
+              width: 100%;
+              height: 50px;
+              position: relative;
+              top: 0;
+              left: 0;
+          }
+
+          #player-container{
+              height: 11.166667%;
+              position: relative;
+              padding-top: 2%;
+              padding-bottom: 2%;
+              min-height: 85px;
+              background: #7CE4E8;
+              margin: 0 0 4% 6%;
+              @include br;
+
+              @include mobile-only{
+                  min-height: 0;
+                  display: inline-block;
+                  margin: 0px .5%;
+                  width: 15.5%;
+                  height: 48px;
+                  padding-top: 1%;
+                  padding-bottom: 0;
+              }
+
+              #above-czar-container{
+                  height: 65%;
+                  width: 100%;
+
+                  @include mobile-only{
+                      height: 100%;
+                  }
+
+
+                      #king {
+                          position: absolute;
+                          max-width: 80%;
+                          bottom: 20px;
+                          -webkit-transform: rotate(-18deg);
+                          left: -5px;
+
+                          @include tablet-portrait-only {
+                              max-width: 80%;
+                              bottom: 27px;
+                          }
+
+                          @include mobile-only {
+                              max-width: 80%;
+                              bottom: 31px;
+                              left: -3px;
+                          }
+
+
+                      img {
+                          width: 100%;
+                          height: 140%;
+                          float: left;
+                          @include br;
+                          min-width: 40px;
+                          min-height: 40px;
+
+                          @include tablet-portrait-only{
+                              width: 100%;
+                              height: 100%;
+                              margin-left: 3px;
+                          }
+
+                          @include mobile-only{
+                              height: 69%;
+                              width: 100%;
+                              min-height: 0;
+                              min-width: 0;
+                              margin: 0;
+                          }
+                      }
+                  }
+                  #player-container-inner{
+                      float: left;
+                      position: relative;
+                      bottom: 8px;
+                      left: 2px;
+                      max-width: 62%;
+                      overflow: hidden;
+
+                      @include tablet-portrait-only{
+                          left: 3px;
+                      }
+
+                      @include mobile-only{
+                          bottom: 0;
+                          left: 0;
+                          height: 100%;
+                          width: 60%;
+                      }
+
+                      #player-name{
+
+                          h4{
+                              font-family: 'Lobster', cursive;
+                              margin-bottom: 0px;
+                          }
+                          h4{
+
+                              @include tablet-portrait-only{
+                                  font-size: 14px;
+                              }
+
+                              @include mobile-only{
+                                  font-family: 'Lobster', cursive;
+                                  font-size: 10px;
+                                  margin-top: 3px;
+                                  margin-bottom: 5px;
+                              }
+                          }
+                      }
+
+                      #player-score{
+                          float: left;
+
+                          h2{
+
+                              font-size: 18px;
+                              margin-top: 0;
+                              margin-bottom: 0;
+
+                              @include tablet-portrait-only{
+                                  font-size: 21px;
+                              }
+
+                              @include mobile-only{
+                                  font-size: 17px;
+                                  line-height: 40%;
+                              }
+                          }
+                      }
+
+                      #player-star{
+                      float: left;
+                      margin-top: 3px;
+                      margin-left: 10px;
+
+                      @include tablet-portrait-only{
+                          margin-top: 1px;
+                          margin-left: 5px;
+                      }
+
+                      @include mobile-only{
+                          display: none;
+                      }
+
+                          img {
+                              width: 22px;
+
+                              @include tablet-portrait-only{
+                                  width: 18px;
+                              }
+                          }
+                      }
+                  }
+              }
+
+              #czar-container {
+                  position: absolute;
+                  bottom: 0;
+                  text-align: center;
+                  width: 100%;
+                  @include br-bottom;
+                  background: #000000;
+                  opacity:0.4;
+
+                  @include mobile-only{
+                      overflow: auto;
+                  }
+
+                  #the-czar{
+                      color: #ffffff;
+                      font-weight: bold;
+                      font-size: 20px;
+
+                      @include mobile-only{
+                          display: none;
+                      }
+                  }
+              }
+          }
+      }
+
+      #gameplay-container{
+          height: 100%;
+          width: 80%;
+
+          @include mobile-only{
+              width: 100%;
+              height: 91%;
+          }
+
+          #upper-gameplay-container {
+              height: 28%;
+              width: 100%;
+              min-height: 220px;
+              max-height: 220px;
+
+              @include mobile-only{
+                  min-height: 140px;
+                  max-height: 140px;
+
+              }
+
+              @include tablet-portrait-only{
+                  height: 16%;
+                  min-height: 180px;
+                  max-height: 180px;
+              }
+
+              #menu-timeremaining-container{
+                  float: left;
+                  width: 19%;
+                  height: 100%;
+                  margin-right: 2%;
+
+                  @include tablet-portrait-only{
+                      width: 21%;
+                  }
+
+                  @include mobile-only{
+                      width: 27%;
+                      margin-right: 1%;
+                  }
+
+                  #menu-container{
+                      display: none;
+                      @include soft-button;
+                      height: 20%;
+                      margin-bottom: 16px;
+                      line-height: 20%;
+                      @include br;
+
+                      #menu-button{
+                          position: absolute;
+                          top: 50%;
+                          left: 0;
+                          right: 0;
+                      }
+                  }
+
+                  #timer-container {
+                      height: 70%;
+
+                      #inner-timer-container{
+                          text-align: center;
+                          @include soft-button;
+                          background: #808080;
+                          text-shadow: none;
+                          cursor: default;
+                          border: none;
+                          min-width: 65px;
+                          min-height: 85px;
+                          height: 100%;
+                          color: #ffffff;
+
+                          #timer-status-round, #timer-status-czar-choosing{
+                              position: absolute;
+                              left: 0;
+                              right: 0;
+                              padding-top: 5px;
+                              padding-bottom: 8px;
+                              bottom: 0;
+
+                              @include tablet-landscape-and-below{
+                                  font-size: 13px;
+                              }
+
+                              @include mobile-only{
+                                  font-size: 12px;
+                              }
+                          }
+
+                          #time{
+                              font-family: 'Lobster', cursive;
+                              font-size: 90px;
+                              position: absolute;
+                              bottom: 15%;
+                              left: 0;
+                              right: 0;
+
+                              @include tablet-landscape-and-below{
+                                  font-size: 90px;
+                              }
+
+                              @include mobile-only{
+                                  font-size: 73px;
+                              }
+                          }
+                      }
+                  }
                 }
 
-                #first-word{
-                    color: #000000;
-                }
-
-                #second-word{
-                    color: #000000;
-                }
-
-                #third-word{
-                    color: #000000;
-                }
-            }
-
-            #abandon-game-button{
-                display: inline-block;
-                float: right;
-                border-radius: 8px;
-                -moz-border-radius: 8px;
-                -webkit-border-radius: 8px;
-                font-size: 20px;
-                font-size: 1.25rem;
-                font-weight: 400;
-                text-align: center;
-                color: white;
-                background: #000000;
-                margin-top: 3px;
-                margin-bottom: 3px;
-                margin-right: 10px;
-                padding: 0.65em 20px;
-                width: 140px;
-                cursor: pointer;
-
-                @include mobile-only{
-                    font-size: 0.7rem;
-                    margin-top: 5px;
-                    margin-right: 1px;
-                    padding: 5px;
-                    width: 60px;
-                }
-            }
-
-            #abandon-game-button:hover{
-               background:#F34444;
-            }
-
-            #tweet-container{
-                float: right;
-                padding-top: 10px;
-                width: 87px;
-                margin-right: 5px;
-
-                @include mobile-only{
-                    float: right;
-                    padding-top: 6px;
-                    width: 55px;
-                    overflow: hidden;
-                    margin-right: 11px;
-                }
-
-                .hcount .count-o{
-                    display: none !important;
-                    width: 0 !important;
-                }
-
-                .count-0{
-                    width: 0 !important;
-                }
-
-                .count-ready .count-o {
-                    visibility: visible;
-                    visibility: hidden !important;
-                }
-            }
-        }
-
-        #social-bar-container{
-            width: 20%;
-            height: 20%;
-            position: absolute;
-            right: 0;
-            top: 60px;
-
-            @include mobile-only{
-                top: auto;
-                width: 100%;
-                height: 50px;
-                position: relative;
-                top: 0;
-                left: 0;
-            }
-
-            #player-container{
-                height: 11.166667%;
-                position: relative;
-                padding-top: 2%;
-                padding-bottom: 2%;
-                min-height: 85px;
-                background: #7CE4E8;
-                margin: 0 0 2% 4%;
-                @include br;
-
-                @include mobile-only{
-                    min-height: 0;
-                    display: inline-block;
-                    margin: 0px .5%;
-                    width: 15.5%;
-                    height: 48px;
-                    padding-top: 1%;
-                    padding-bottom: 0;
-                }
-
-                #above-czar-container{
-                    height: 65%;
-                    width: 100%;
-
-                    @include mobile-only{
-                        height: 100%;
-                    }
-
-
-                        #king {
-                           position: absolute;
-                           max-width: 80%;
-                           bottom: 20px;
-                           -webkit-transform: rotate(-18deg);
-                           left: -5px;
-
-                           @include tablet-portrait-only {
-                                max-width: 80%;
-                                bottom: 27px;
-                           }
-
-                           @include mobile-only {
-                                max-width: 80%;
-                                bottom: 31px;
-                                left: -3px;
-                           }
-
-
-                        img {
-                            width: 100%;
-                            height: 140%;
-                            float: left;
-                            @include br;
-                            min-width: 40px;
-                            min-height: 40px;
-
-                            @include tablet-portrait-only{
-                                width: 100%;
-                                height: 100%;
-                                margin-left: 3px;
-                            }
-
-                            @include mobile-only{
-                                height: 69%;
-                                width: 100%;
-                                min-height: 0;
-                                min-width: 0;
-                                margin: 0;
-                            }
-                        }
-                    }
-                    #player-container-inner{
-                        float: left;
-                        position: relative;
-                        bottom: 8px;
-                        left: 2px;
-                        max-width: 62%;
-                        overflow: hidden;
-
-                        @include tablet-portrait-only{
-                            left: 3px;
-                        }
-
-                        @include mobile-only{
-                            bottom: 0;
-                            left: 0;
-                            height: 100%;
-                            width: 60%;
-                        }
-
-                        #player-name{
-
-                            h4{
-                                font-family: 'Lobster', cursive;
-                                margin-bottom: 0px;
-                            }
-                            h4{
-
-                                @include tablet-portrait-only{
-                                    font-size: 14px;
-                                }
-
-                                @include mobile-only{
-                                    font-family: 'Lobster', cursive;
-                                    font-size: 10px;
-                                    margin-top: 3px;
-                                    margin-bottom: 5px;
-                                }
-                            }
-                        }
-
-                        #player-score{
-                            float: left;
-
-                            h2{
-
-                                font-size: 18px;
-                                margin-top: 0;
-                                margin-bottom: 0;
-
-                                @include tablet-portrait-only{
-                                    font-size: 21px;
-                                }
-
-                                @include mobile-only{
-                                    font-size: 17px;
-                                    line-height: 40%;
-                                }
-                            }
-                        }
-
-                        #player-star{
-                        float: left;
-                        margin-top: 3px;
-                        margin-left: 10px;
-
-                        @include tablet-portrait-only{
-                            margin-top: 1px;
-                            margin-left: 5px;
-                        }
-
-                        @include mobile-only{
-                            display: none;
-                        }
-
-                            img {
-                                width: 22px;
-
-                                @include tablet-portrait-only{
-                                    width: 18px;
-                                }
-                            }
-                        }
-                    }
-                }
-
-                #czar-container {
-                    position: absolute;
-                    bottom: 0;
-                    text-align: center;
-                    width: 100%;
-                    @include br-bottom;
-                    background: #000000;
-                    opacity:0.4;
-
-                    @include mobile-only{
-                        overflow: auto;
-                    }
-
-                    #the-czar{
-                        color: #ffffff;
-                        font-weight: bold;
-                        font-size: 20px;
-
-                        @include mobile-only{
-                            display: none;
-                        }
-                    }
-                }
-            }
-        }
-
-        #gameplay-container{
-            height: 100%;
-            width: 80%;
-
-            @include mobile-only{
-                width: 100%;
-                height: 91%;
-            }
-
-            #upper-gameplay-container {
-                height: 28%;
-                width: 100%;
-                min-height: 220px;
-                max-height: 220px;
-
-                @include mobile-only{
-                    min-height: 140px;
-                    max-height: 140px;
-
-                }
-
-                @include tablet-portrait-only{
-                    height: 16%;
-                    min-height: 180px;
-                    max-height: 180px;
-                }
-
-                #menu-timeremaining-container{
-                    float: left;
-                    width: 19%;
-                    height: 100%;
-                    margin-right: 2%;
-
-                    @include tablet-portrait-only{
-                        width: 21%;
-                    }
-
-                    @include mobile-only{
-                        width: 27%;
-                        margin-right: 1%;
-                    }
-
-                    #menu-container{
-                        display: none;
-                        @include soft-button;
-                        height: 20%;
-                        margin-bottom: 16px;
-                        line-height: 20%;
-                        @include br;
-
-                        #menu-button{
-                            position: absolute;
-                            top: 50%;
-                            left: 0;
-                            right: 0;
-                        }
-                    }
-
-                    #timer-container {
-                        height: 70%;
-
-                        #inner-timer-container{
-                            text-align: center;
-                            @include soft-button;
-                            background:#808080;
-                            text-shadow: none;
-                            cursor: default;
-                            border: none;
-                            min-width: 65px;
-                            min-height: 85px;
-                            height: 100%;
-                            color: #ffffff;
-
-                            #timer-status-round, #timer-status-czar-choosing{
-                                position: absolute;
-                                left: 0;
-                                right: 0;
-                                padding-top: 5px;
-                                padding-bottom: 8px;
-                                bottom: 0;
-
-                                @include tablet-landscape-and-below{
-                                    font-size: 13px;
-                                }
-
-                                @include mobile-only{
-                                    font-size: 12px;
-                                }
-                            }
-
-                            #time{
-                                font-family: 'Lobster', cursive;
-                                font-size: 90px;
-                                position: absolute;
-                                bottom: 15%;
-                                left: 0;
-                                right: 0;
-
-                                @include tablet-landscape-and-below{
-                                    font-size: 90px;
-                                }
-
-                                @include mobile-only{
-                                    font-size: 73px;
-                                }
-                            }
-                        }
-                    }
-                 }
-
-                #question-container-outer {
-                    height: 80%;
-                    float: left;
-                    width: 79%;
-
-                    @include tablet-portrait-only{
-                        width: 77%;
-                        float: right;
-                    }
-
-                    @include mobile-only{
-                        float: left;
-                        width: 71%;
-                        margin-left: 1%;
-                    }
-
-                    #question-container-inner{
-                        width: 80%;
-                        height: 80%;
-                        .card{
-                            width: 100%;
-                            margin: 15px auto;
-                            display: block;
-
-                            #notifications {
-                                position: absolute;
-                                bottom: 0;
-                                right: 0;
-                                padding: 10px;
-                            }
-
-                            #startGame{
-                                width: 100%;
-                                overflow: hidden;
-                                height: 100%;
-                                position: absolute;
-                                right: 1%;
-
-                                #finding-players {
-                                    font-size: 33px;
-                                    text-align: center;
-                                    margin-top: 15px;
-
-                                    @include mobile-only{
-                                        font-size: 21px;
-                                        margin-top: 0;
-                                    }
-                                }
-
-                                #player-count-container, #loading-container, #start-game-container{
-                                    width: 33.333%;
-                                    float: left;
-                                    text-align: center;
-                                }
-
-                                #player-count-container{
-                                    #player-count{
-                                        font-size: 25px;
-
-                                        @include mobile-only{
-                                            font-size: 21px;
-                                        }
-                                    }
-                                    #the-word-players{
-                                        font-size: 17px;
-                                    }
-                                }
-
-                                #loading-gif{
-                                    margin: 20px;
-
-                                    @include mobile-only{
-                                        margin-top: 5px;
-                                    }
-                                }
-
-                                #start-game-container{
-                                    color: #333;
-
-                                    #start-game-button{
-                                        border-radius: 8px;
-                                        -moz-border-radius: 5px;
-                                        -webkit-border-radius: 5px;
-                                        font-size: 20px;
-                                        font-size: 1.25rem;
-                                        font-weight: 400;
-                                        color: white;
-                                        background: #1F959C;
-                                        padding: 0.65em 20px;
-                                        margin: 10px;
-                                        width: 65%;
-                                        cursor: pointer;
-
-                                        @include tablet-portrait-only{
-                                            padding: 0.65em 2px;
-                                            font-size: 1.1rem;
-                                        }
-
-                                        @include mobile-only{
-                                            padding: 0.65em 1px;
-                                            font-size: 1rem;
-                                        }
-                                    }
-                                                                      
-                                    #start-game-button:hover{
-                                       background:#41C2CA;
-                                    }
-                                }
-                            }
-
-                            #game-end-info{
-                                text-align: center;
-                                font-size: 16px;
-
-                                @include mobile-only{
-                                    font-size: 13px;
-                                }
-
-                                .game-end-headline{
-                                    font-size: 24px;
-                                    margin-bottom: 10px;
-
-                                    @include mobile-only{
-                                        font-size: 18px;
-                                    }
-                                }
-
-                            }
-                        }
-                    }
-                }
-            }
-            #info-container{
-                width: 90%;
-                background: #252525;
-                color: #ffffff;
-                @include br;
-                text-align: center;
-                padding: 15px;
-                height: auto;
-                margin-top: 10px;
-
-                @include tablet-portrait-only{
-                    padding-top: 5px;
-                    height: auto;
-                }
-
-                @include mobile-only{
-                    width: 100%;
-                    padding: 1px;
-                    margin: 0px auto;
-                    height: 72%;
-                }
-
-                #inner-info{
-                    width: 90%;
-                    margin: 0 5%;
-
-                    #lobby-how-to-play{
-                        font-size: 40px;
-                        text-decoration: underline;
-                        margin-top: 10px;
-
-                        @include tablet-portrait-only{
-                            font-size: 14px;
-                        }
-                    }
-
-                    ul{
-                        margin-top: 10px;
-                        font-family: $main-font;
-                        text-align: left;
-                        font-size: 25px;
-
-                        li{
-                            list-style-type: disc;
-                            margin-bottom: 5px;
-                        }
-
-                        @include mobile-only{
-                            font-size: 13px;
-                            padding: 0px 10px 10px 10px;
-                        }
-                    }
-                }
-            }
-
-            #game-end-container{
-                width: 100%;
-                background: #252525;
-                @include br;
-                text-align: center;
-                overflow: hidden;
-                height: 50%;
-                margin-top: 10px;
-
-                @include mobile-only{
-                    height: 65%;
-                }
-
-                #charity-widget-container{
-                    width: 40%;
-                    float: left;
-
-                    @include mobile-only{
-                        display: none;
-                    }
-                }
-
-                #inner-info-exit{
-                    width: 60%;
-                    position: relative;
-                    overflow: hidden;
-                    height: 100%;
-                    color: white;
-                    float: left;
-
-                    @include mobile-only{
-                        float: none;
-                        width: 80%;
-                    }
-
-                    .game-end-answer-text{
-                        color: white;
-
-                        @include mobile-only{
-                            padding: 6px;
-                            font-size: 22px;
-                        }
-                    }
-
-                    @include mobile-only{
-                        width: 100%;
-                    }
-
-                    #inner-text-container{
-                        overflow: hidden;
-                        height: 100%;
-
-                        @include mobile-only{
-                            height: auto;
-                        }
-
-                        #join-new-game{
-                            float: left;
-                            @include button-smaller;
-                            width: 40%;
-                            margin: 5%;
-                            height: 28%;
-                            font-size: 21px;
-                            line-height: 155%;
-                            padding-top: 5%;
-
-                             &:hover{
-                                @include button-hover-smaller;
-                            }
-                        }
-
-                        #exit-match{
-                            float: left;
-                            @include button-smaller;
-                            width: 40%;
-                            margin: 5%;
-                            height: 28%;
-                            font-size: 21px;
-                            line-height: 155%;
-                            padding-top: 5%;
-
-                             &:hover{
-                                @include button-hover-smaller;
-                            }
-                        }
-
-                    }
-                }
-            }
-
-            #czar-blank-container{
-                color: white;
-                width: 100%;
-                background: #252525;
-                @include br;
-                text-align: center;
-                overflow: hidden;
-                height: 50%;
-                position: relative;
-                margin-top: 10px;
-                font-size: 30px;
-
-                @include mobile-only{
-                    width: 100%;
-                    font-size: 16px;
-                    margin: 0px auto;
-                }
-
-                #czar-blank-inner{
-                    position: absolute;
-                    left: 10%;
-                    right: 10%;
-                    width: 80%;
-                    height: 50px;
-                    margin-top: 5%;
-
-                    #smaller-text{
-                        font-size: 18px;
-                    }
-                }
-
-                #charity-fact-container{
-                    @include br;
-                    background-color: #ffffff;
-                    color:#000000;
-
-                    position: absolute;
-                    bottom: 4%;
-                    margin: 0 2%;
-                    width: 96%;
-                    padding: 3px;
-                    text-align: left;
-
-                    @include mobile-only{
-                        height: 40%;
-                        display: none;
-                    }
-
-                    #charity-fact-tagline{
-                        font-family: 'Lobster', cursive;
-                        font-size: 22px;
-                        margin-left: 2%;
-                        margin-bottom: 3px;
-                        color: #000;
-
-                        @include mobile-only{
-                            font-size: 16px;
-                        }
-                    }
-
-                    #charity-fact{
-                        font-size: 14px;
-                        font-style: italic;
-                        text-align: center;
-                        width: 90%;
-                        margin: 0 5% 3px 5%;
-
-                        @include mobile-only{
-                            font-size: 12px;
-                        }
-                    }
-
-                    #charity-logo-container{
-
-                        @include mobile-only{
-                            position: absolute;
-                            top: 1px;
-                            right: 0;
-                        }
-
-                        img{
-                            float: right;
-                            margin-right: 2%;
-                            margin-bottom: 3px;
-
-                            @include mobile-only{
-                                width: 53%;
-                            }
-                        }
-                    }
-                }
-            }
-
-            #cards-container{
-                width: 100%;
-                background: transparent;
-                margin-top: 11px;
-                @include br;
-
-                @include mobile-only{
-                    background: transparent;
-                    margin-top: 2px;
-                }
-
-                #cards {
-                    width: 100%;
-                    height: 100%;
-                    font-size: 18px;
-                    padding-left: 5px;
-
-                    @include mobile-only{
-                        background: #252525;
-                        -webkit-border-radius: 8px;
-                        -moz-border-radius: 8px;
-                        border-radius: 8px;
-                        max-height: 245px;
-                    }
-                }
-            }
-        }
-    }
+              #question-container-outer {
+                  float: left;
+                  height: 80%;
+                  width: 79%;
+
+                  @include tablet-portrait-only{
+                      width: 77%;
+                      float: right;
+                  }
+
+                  @include mobile-only{
+                      float: left;
+                      width: 71%;
+                      margin-left: 1%;
+                  }
+
+                  #question-container-inner{
+                      height: 80%;
+                      width: 80%;
+                      .card{
+                          width: 100%;
+                          margin: 15px auto;
+                          display: block;
+
+                          #notifications {
+                              position: absolute;
+                              bottom: 0;
+                              right: 0;
+                              padding: 10px;
+                          }
+
+                          #startGame{
+                              width: 100%;
+                              overflow: hidden;
+                              height: 100%;
+                              position: absolute;
+                              right: 1%;
+
+                              #finding-players {
+                                  font-size: 33px;
+                                  text-align: center;
+                                  margin-top: 15px;
+
+                                  @include mobile-only{
+                                      font-size: 21px;
+                                      margin-top: 0;
+                                  }
+                              }
+
+                              #player-count-container, #loading-container, #start-game-container{
+                                  width: 33.333%;
+                                  float: left;
+                                  text-align: center;
+                              }
+
+                              #player-count-container{
+                                  #player-count{
+                                      font-size: 25px;
+
+                                      @include mobile-only{
+                                          font-size: 21px;
+                                      }
+                                  }
+                                  #the-word-players{
+                                      font-size: 17px;
+                                  }
+                              }
+
+                              #loading-gif{
+                                  margin: 20px;
+
+                                  @include mobile-only{
+                                      margin-top: 5px;
+                                  }
+                              }
+
+                              #start-game-container{
+                                  color: #333;
+
+                                  #start-game-button{
+                                      border-radius: 8px;
+                                      -moz-border-radius: 5px;
+                                      -webkit-border-radius: 5px;
+                                      font-size: 20px;
+                                      font-size: 1.25rem;
+                                      font-weight: 400;
+                                      color: white;
+                                      background: #1F959C;
+                                      padding: 0.65em 20px;
+                                      margin: 10px;
+                                      width: 65%;
+                                      cursor: pointer;
+
+                                      @include tablet-portrait-only{
+                                          padding: 0.65em 2px;
+                                          font-size: 1.1rem;
+                                      }
+
+                                      @include mobile-only{
+                                          padding: 0.65em 1px;
+                                          font-size: 1rem;
+                                      }
+                                  }
+                                                                    
+                                  #start-game-button:hover{
+                                      background:#41C2CA;
+                                  }
+                              }
+                          }
+
+                          #game-end-info{
+                              text-align: center;
+                              font-size: 16px;
+
+                              @include mobile-only{
+                                  font-size: 13px;
+                              }
+
+                              .game-end-headline{
+                                  font-size: 24px;
+                                  margin-bottom: 10px;
+
+                                  @include mobile-only{
+                                      font-size: 18px;
+                                  }
+                              }
+
+                          }
+                      }
+                  }
+              }
+          }
+          #info-container{
+              background: #252525;
+              color: #ffffff;
+              width: 90%;
+
+              @include br;
+              height: auto;
+              margin-top: 10px;
+              padding: 15px;
+              text-align: center;
+              
+              
+              
+
+              @include tablet-portrait-only{
+                  padding-top: 5px;
+                  height: auto;
+              }
+
+              @include mobile-only{
+                  width: 100%;
+                  padding: 1px;
+                  margin: 0px auto;
+                  height: 72%;
+              }
+
+              #inner-info{
+                  width: 90%;
+                  margin: 0 5%;
+
+                  #lobby-how-to-play{
+                      font-size: 40px;
+                      margin-top: 10px;
+                      text-decoration: underline;
+
+                      @include tablet-portrait-only{
+                          font-size: 14px;
+                      }
+                  }
+                  ul {
+                      margin-top: 10px;
+                      font-family: $main-font;
+                      text-align: left;
+                      font-size: 25px;
+
+                      li{
+                          list-style-type: disc;
+                          margin-bottom: 5px;
+                      }
+
+                      @include mobile-only{
+                          font-size: 13px;
+                          padding: 0px 10px 10px 10px;
+                      }
+                  }
+              }
+          }
+
+          #game-end-container{
+              width: 100%;
+              background: #252525;
+              @include br;
+              text-align: center;
+              overflow: hidden;
+              height: 50%;
+              margin-top: 10px;
+
+              @include mobile-only{
+                  height: 65%;
+              }
+
+              #charity-widget-container{
+                  width: 40%;
+                  float: left;
+
+                  @include mobile-only{
+                      display: none;
+                  }
+              }
+
+              #inner-info-exit{
+                  width: 60%;
+                  position: relative;
+                  overflow: hidden;
+                  height: 100%;
+                  color: white;
+                  float: left;
+
+                  @include mobile-only{
+                      float: none;
+                      width: 80%;
+                  }
+
+                  .game-end-answer-text{
+                      color: white;
+
+                      @include mobile-only{
+                          padding: 6px;
+                          font-size: 22px;
+                      }
+                  }
+
+                  @include mobile-only{
+                      width: 100%;
+                  }
+
+                  #inner-text-container{
+                      overflow: hidden;
+                      height: 100%;
+
+                      @include mobile-only{
+                          height: auto;
+                      }
+
+                      #join-new-game{
+                          float: left;
+                          @include button-smaller;
+                          width: 40%;
+                          margin: 5%;
+                          height: 28%;
+                          font-size: 21px;
+                          line-height: 155%;
+                          padding-top: 5%;
+
+                            &:hover{
+                              @include button-hover-smaller;
+                          }
+                      }
+
+                      #exit-match{
+                          float: left;
+                          @include button-smaller;
+                          width: 40%;
+                          margin: 5%;
+                          height: 28%;
+                          font-size: 21px;
+                          line-height: 155%;
+                          padding-top: 5%;
+
+                            &:hover{
+                              @include button-hover-smaller;
+                          }
+                      }
+
+                  }
+              }
+          }
+
+          #czar-blank-container{
+              color: white;
+              width: 100%;
+              background: #252525;
+              @include br;
+              text-align: center;
+              overflow: hidden;
+              height: 50%;
+              position: relative;
+              margin-top: 10px;
+              font-size: 30px;
+
+              @include mobile-only{
+                  width: 100%;
+                  font-size: 16px;
+                  margin: 0px auto;
+              }
+
+              #czar-blank-inner{
+                  position: absolute;
+                  left: 10%;
+                  right: 10%;
+                  width: 80%;
+                  height: 50px;
+                  margin-top: 5%;
+
+                  #smaller-text{
+                      font-size: 18px;
+                  }
+              }
+
+              #charity-fact-container{
+                  @include br;
+                  background-color: #ffffff;
+                  color:#000000;
+
+                  position: absolute;
+                  bottom: 4%;
+                  margin: 0 2%;
+                  width: 96%;
+                  padding: 3px;
+                  text-align: left;
+
+                  @include mobile-only{
+                      height: 40%;
+                      display: none;
+                  }
+
+                  #charity-fact-tagline{
+                      font-family: 'Lobster', cursive;
+                      font-size: 22px;
+                      margin-left: 2%;
+                      margin-bottom: 3px;
+                      color: #000;
+
+                      @include mobile-only{
+                          font-size: 16px;
+                      }
+                  }
+
+                  #charity-fact{
+                      font-size: 14px;
+                      font-style: italic;
+                      text-align: center;
+                      width: 90%;
+                      margin: 0 5% 3px 5%;
+
+                      @include mobile-only{
+                          font-size: 12px;
+                      }
+                  }
+
+                  #charity-logo-container{
+
+                      @include mobile-only{
+                          position: absolute;
+                          top: 1px;
+                          right: 0;
+                      }
+
+                      img{
+                          float: right;
+                          margin-right: 2%;
+                          margin-bottom: 3px;
+
+                          @include mobile-only{
+                              width: 53%;
+                          }
+                      }
+                  }
+              }
+          }
+
+          #cards-container{
+              width: 100%;
+              background: transparent;
+              margin-top: 11px;
+              @include br;
+
+              @include mobile-only{
+                  background: transparent;
+                  margin-top: 2px;
+              }
+
+              #cards {
+                  width: 100%;
+                  height: 100%;
+                  font-size: 18px;
+                  padding-left: 5px;
+
+                  @include mobile-only{
+                      background: #252525;
+                      -webkit-border-radius: 8px;
+                      -moz-border-radius: 8px;
+                      border-radius: 8px;
+                      max-height: 245px;
+                  }
+              }
+          }
+      }
+  }
 }
 
 #notifications{
 
-    @include tablet-portrait-only{
-        font-size: 18px;
-    }
-    @include mobile-only{
-        font-size: 15px;
-    }
+  @include tablet-portrait-only{
+      font-size: 18px;
+  }
+  @include mobile-only{
+      font-size: 15px;
+  }
 }
 
 
 
 //Attempt to Modify our Charity Banner
 .crDonateWidget {
-    -webkit-box-shadow: 0px 0px 0px 0px transparent !important;
-    -moz-box-shadow: 0px 0px 0px 0px transparent !important;
-    box-shadow: 0px 0px 0px 0px transparent !important;
-    -webkit-border-radius: 8px !important;
-    -moz-border-radius: 8px !important;
-    border-radius: 8px !important;
+  -webkit-box-shadow: 0px 0px 0px 0px transparent !important;
+  -moz-box-shadow: 0px 0px 0px 0px transparent !important;
+  box-shadow: 0px 0px 0px 0px transparent !important;
+  -webkit-border-radius: 8px !important;
+  -moz-border-radius: 8px !important;
+  border-radius: 8px !important;
 }
 
 .crDonateWidgetOuter {
-    text-align: center;
-    background-color: transparent !important;
-    -webkit-box-shadow: 0px 0px 0px 0px rgba(0,0,0,0.0) !important;
-    box-shadow: 0px 0px 0px 0px rgba(0,0,0,0.0) !important;
-    border: 0px solid #e6e6e6 !important;
-    margin: 0px 0px !important;
+  text-align: center;
+  background-color: transparent !important;
+  -webkit-box-shadow: 0px 0px 0px 0px rgba(0,0,0,0.0) !important;
+  box-shadow: 0px 0px 0px 0px rgba(0,0,0,0.0) !important;
+  border: 0px solid #e6e6e6 !important;
+  margin: 0px 0px !important;
 }
 
 .crDonated{
-    margin-top: 2px !important;
+  margin-top: 2px !important;
 }
 
 .crImageAndTitle{
-    display: none;
+  display: none;
 }
 
 .crImageAndTitleOuter{
-    display: none;
+  display: none;
 }
 
 .startFundraiser{
-    display: none;
+  display: none;
 }
 
 #crDonateWidget_cfhio_cards4humanity{
-    width: 90% !important;
-    margin-top: 67px !important;
+  width: 90% !important;
+  margin-top: 67px !important;
 
-    .crDonateTriangle{
-        right: 6px !important;
-    }
-    h4{
-        margin-bottom: 8px !important;
-    }
+  .crDonateTriangle{
+      right: 6px !important;
+  }
+  h4{
+      margin-bottom: 8px !important;
+  }
 }
 
 
 
 .gradientButton{
-    width: 80% !important;
-    margin-top: 8px !important;
-    background: rgb(244,120,31) !important;
-    -webkit-border-radius: 8px !important;
-    -moz-border-radius: 8px !important;
-    border-radius: 8px !important;
-    text-transform: none !important;
-    .donateNow{
-        border-top: 0px solid #000000 !important;
-    }
+  width: 80% !important;
+  margin-top: 8px !important;
+  background: rgb(244,120,31) !important;
+  -webkit-border-radius: 8px !important;
+  -moz-border-radius: 8px !important;
+  border-radius: 8px !important;
+  text-transform: none !important;
+  .donateNow{
+      border-top: 0px solid #000000 !important;
+  }
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -218,7 +218,7 @@
  }
 
  .wpb-logo-container a {
-   color: cyan !important;
+   color: black !important;
  }
 
 
@@ -251,7 +251,7 @@
  }
 
   .wpb-menu-container .wpb-main-menu li a:hover {
-   color: black!important;
+   color: cyan!important;
    -webkit-transition: color 0.5s ease;
    -moz-transition: color 0.5s ease;
    -ms-transition: color 0.5s ease;

--- a/public/views/answers.html
+++ b/public/views/answers.html
@@ -15,7 +15,7 @@
 
     <span ng-repeat="answer in game.table">
         <div class="card smallest" ng-style="pointerCursorStyle()" id='table' ng-click="pickWinning(answer)" ng-show="showTable || isCzar()"
-        ng-repeat="card in answer.card" ng-animate="{enter:'animated bounceInLeft'}" style="background-color:{{winningColor($parent.$index)}}">
+        ng-repeat="card in answer.card" ng-animate="{enter:'animated bounceInLeft'}" style="background-color: {winningColor($parent.$index)}">
             <span ng-bind-html-unsafe="card.text"></span>
             <span id='selection-number' ng-show="firstAnswer($index)"> 1 </span>
             <span id='selection-number' ng-show="secondAnswer($index)"> 2 </span>
@@ -28,13 +28,13 @@
 <div id="info-container" ng-show="game.state === 'awaiting players'">
   <div id="inner-info">
     <div id="lobby-how-to-play">How To Play</div>
-    <ol id="oh-el">
+    <ul id="oh-el">
       <li>Each player begins with, and will always have, 10 white answer cards.</li>
       <li>For each round, one player is randomly chosen as the Card Czar.</li>
       <li>Everyone else answers the black question card by clicking on the answer card they want to use.</li>
       <li>The Card Czar then picks a favorite answer, and whoever played that answer wins the round.</li>
-      <li>*Want to adorn your avatar with a glorious crown? Donate to charity after the game!</li>
-    </ol>
+      <li>Want to adorn your avatar with a glorious crown?<strong>Donate to charity</strong> after the game!</li>
+    </ul>
   </div>
 </div>
 <div id="game-end-container" ng-show="game.state === 'game ended' || game.state ==='game dissolved'">

--- a/public/views/player.html
+++ b/public/views/player.html
@@ -1,14 +1,14 @@
 <div id="player-container" ng-repeat="player in game.players" style="background-color:{{colors[player.color]}}">
   <div id ="above-czar-container">
-    <div id="avatar_">
+    <!--<div id="avatar_">
       <span ng-show="isPremium($index)">
         <img ng-src="img/king.png" id="king">
       </span>
       <img ng-src="{{player.avatar}}"/>
-    </div>
+    </div>-->
     <div id="player-container-inner">
       <div id="player-name"><h4>{{player.username | upperFirstLetter}}</h4></div>
-      <div id="player-score"><h2>{{player.points}}/{{game.pointLimit}}</h2></div>
+      <div id="player-score"><h4>Points:{{player.points}}/{{game.pointLimit}}</h4></div>
       <div ng-show="isPlayer($index)" id="player-star">
         <img src="../img/11.png"/>
       </div>


### PR DESCRIPTION
 #### What does this PR do?
- Changes the design of the screen a user sees when playing the game
 #### Description of Task to be completed?
- Re-design the screens a user interacts with when playing the game in tandem with the new theme.
 #### How should this be manually tested?
- run `npm start`
- Click on the ```Start Game``` button
- Select the `Play with Friends` option
- Copy the link given and copy it.
- Paste the ink in multiple tabs (to simulate other players joining the game)
- Navigate to the original page and click on the `Start game with _ players` (where the _ represents the number of tabs opened)
- This should enable interaction with the gaming screens.
 #### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/143412465
 #### Screenshots (if appropriate)
<img width="1432" alt="screenshot 2017-05-16 15 55 43" src="https://cloud.githubusercontent.com/assets/27014312/26106972/76ed63f6-3a50-11e7-8c04-2d8f505eeb7c.png">
<img width="1435" alt="screenshot 2017-05-16 15 57 20" src="https://cloud.githubusercontent.com/assets/27014312/26106980/7cc45460-3a50-11e7-8438-a4e20ff17ea3.png">
<img width="1437" alt="screenshot 2017-05-16 15 57 45" src="https://cloud.githubusercontent.com/assets/27014312/26106985/7e8d13fe-3a50-11e7-92cd-09b7e2a5e220.png">
